### PR TITLE
Set target ruby version to 2.5

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisplayCopNames: true
+  TargetRubyVersion: 2.5
 
 Rails:
   Enabled: true

--- a/rubocop-config-coverhound.gemspec
+++ b/rubocop-config-coverhound.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-config-coverhound"
-  spec.version       = "3.1.0"
+  spec.version       = "3.2.0"
   spec.authors       = ["Bernardo Farah"]
   spec.email         = ["ber@bernardo.me"]
   spec.licenses      = ["MIT"]


### PR DESCRIPTION
RubyMine was showing outdated RuboCop errors because it was targeting an older version of Ruby.
Updating the Ruby version to 2.5 resolves this issue and ensures consistency with our current development environment.